### PR TITLE
Update logarithm.md

### DIFF
--- a/docs/src/logarithm.md
+++ b/docs/src/logarithm.md
@@ -5,10 +5,7 @@ end
 ```
 # Logarithmic scales
 
-!!! note
-    Logarithmic scales are new to Unitful and should be considered experimental.
-
-Unitful provides a way to use logarithmically-scaled quantities as of v0.4.0. Some
+Unitful provides a way to use logarithmically-scaled quantities. Some
 compromises have been made in striving for logarithmic quantities to be both usable and
 consistent. In the following discussion, for pedagogical purposes, we will assume prior
 familiarity with the definitions of `dB` and `dBm`.


### PR DESCRIPTION
I suppose Logarithmic scales, introduced at v0.4.0, are no more new to Unitful and experimental.